### PR TITLE
fixed P transform based on GOST example

### DIFF
--- a/functional_spec.v
+++ b/functional_spec.v
@@ -146,7 +146,7 @@ Definition tau : list Z :=
    6; 14; 22; 30; 38; 46; 54; 62;
    7; 15; 23; 31; 39; 47; 55; 63].
 
-Definition p (l : block512) : block512 := permute (rev tau) l.
+Definition p (l : block512) : block512 := permute tau l.
 
 Definition g(N h m: block512) : block512.
 Admitted.


### PR DESCRIPTION
The example in question (line breaks kept), sourced from the English version of the standard linked in the C implementation:

SX[K[1]](m)= 4645d95fc0beec2c432f8914b62d4efd
3e5e37f14b097aead67de417c220b048
2492ac996667e0ebdf45d95fc0beec2c
432f8914b62d4efd3e5e37f14b097aea

PSX[K[1]](m)= 46433ed624df433e452f5e7d92452f5e
d98937e4acd989375f14f117995f14f1
c0b64bc266c0b64bbe2d092067be2d09
ec4e7ab0e0ec4e7a2cfdea48eb2cfdea